### PR TITLE
fix(ci): stop using --accept-flake-config in pull request pre-commit checks

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -68,7 +68,7 @@ jobs:
           purge-primary-key: never
 
       - name: Run pre-commit checks
-        run: nix flake check --accept-flake-config
+        run: nix flake check
 
   config-tests:
     name: "${{ matrix.os-name }} Nix Test"


### PR DESCRIPTION
### Motivation
- Remove the unsafe `--accept-flake-config` usage in the pull-request `pre-commit-checks` job because accepting PR-controlled `flake.nix` `nixConfig` (including substituters and trusted public keys) can let a malicious PR cause `nix flake check` to be validated by attacker-controlled substitutes.

### Description
- Update `.github/workflows/nix.yml` to change the pre-commit step from `run: nix flake check --accept-flake-config` to `run: nix flake check`, keeping the rest of the job unchanged.

### Testing
- Verified the change and committed it by inspecting the workflow with `sed -n '1,220p' .github/workflows/nix.yml`, showing the `git diff -- .github/workflows/nix.yml`, confirming the line with `nl -ba .github/workflows/nix.yml | sed -n '60,80p'`, and successfully committing the update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5da9d92108330a3dd178d4ab4a3cb)