### PR TITLE
fix(security): remove trusted third-party flake caches

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,18 +24,6 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  # Caches
-  nixConfig = {
-    extra-substituters = [
-      "https://nix-community.cachix.org"
-      "https://cache.iog.io"
-    ];
-    extra-trusted-public-keys = [
-      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
-    ];
-  };
-
   outputs =
     { self, ... }@inputs:
     let


### PR DESCRIPTION
### Motivation
- Remove the flake-level `nixConfig` block that added external substituters (`https://nix-community.cachix.org`, `https://cache.iog.io`) and their trusted public keys to eliminate an expanded supply-chain trust boundary for system closures.

### Description
- Deleted the top-level `nixConfig` block from `flake.nix` that set `extra-substituters` and `extra-trusted-public-keys`, preserving all other flake outputs and configuration.

### Testing
- Inspected the file with `nl -ba flake.nix | sed -n '1,140p'` to confirm the vulnerable block existed, verified the removal with `git diff -- flake.nix`, and committed the change with `git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5de17af9c8330aa4610f5d1c499fb)