### PR TITLE
Fix Lightning integration race condition in mempool service

### DIFF
--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -133,6 +133,25 @@
     };
   };
 
+  # Fix Lightning integration for the mempool explorer.
+  #
+  # nix-bitcoin writes the custom `mempool` macaroon into LND's systemd
+  # RuntimeDirectory (`/run/lnd/mempool.macaroon`) via an `ExecStartPost`
+  # script that runs as part of `lnd.service`. The nix-bitcoin `mempool`
+  # backend service, however, only depends on mysql/electrs and has no
+  # ordering relationship with `lnd`. At boot the mempool backend therefore
+  # races LND and frequently starts before the macaroon exists, failing with:
+  #   ERR: Could not initialize LND Macaroon/TLS Cert. Disabling LIGHTNING.
+  #   ENOENT: no such file or directory, open '/run/lnd/mempool.macaroon'
+  #
+  # Ordering the backend after `lnd.service` (which only becomes active once
+  # its ExecStartPost macaroon creation has completed) makes the macaroon
+  # guaranteed to exist before mempool reads it.
+  systemd.services.mempool = {
+    wants = [ "lnd.service" ];
+    after = [ "lnd.service" ];
+  };
+
   # Open ports in the firewall
   networking.firewall.allowedTCPPorts = [
     config.services.bitcoind.port # P2P


### PR DESCRIPTION
## Summary
Fixes a race condition where the mempool backend service starts before LND's macaroon file is created, causing Lightning integration to fail at boot.

## Key Changes
- Added systemd service ordering constraints to `mempool` service to ensure it starts after `lnd.service`
- Set `wants` and `after` dependencies on `lnd.service` to guarantee the LND macaroon file exists before mempool attempts to read it

## Implementation Details
The issue occurred because nix-bitcoin creates the custom `mempool` macaroon file via an `ExecStartPost` script in `lnd.service`, but the mempool backend service had no ordering relationship with LND. This caused mempool to frequently start first and fail with `ENOENT` when trying to open `/run/lnd/mempool.macaroon`.

By adding the service ordering constraints, mempool now waits for `lnd.service` to fully activate (including completion of its `ExecStartPost` macaroon creation) before starting, ensuring the macaroon file is guaranteed to exist.

https://claude.ai/code/session_013CNgTYoD2Fy68rwDJ7Ntki