### PR TITLE
feat(bitcoin): expose mempool frontend via tailscale serve

### DIFF
--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -131,6 +131,25 @@
         permissions = ''{"entity":"info","action":"read"},{"entity":"onchain","action":"read"},{"entity":"offchain","action":"read"},{"entity":"address","action":"read"},{"entity":"message","action":"read"},{"entity":"peers","action":"read"},{"entity":"signer","action":"read"},{"entity":"invoices","action":"read"},{"entity":"macaroon","action":"read"}'';
       };
     };
+
+    # Expose the mempool frontend as a Tailscale Service over HTTPS.
+    #
+    # `services.tailscale.serve` (NixOS 26.05) runs `tailscale serve set-config
+    # --all`, which both writes the serve config and advertises this node as a
+    # proxy for `svc:mempool`. Tailscale terminates TLS on :443 and reverse
+    # proxies to the local mempool frontend.
+    #
+    # Still required out-of-band in the Tailscale admin console:
+    #   * enable MagicDNS + HTTPS Certificates for the tailnet
+    #   * approve the advertised `svc:mempool` service (or set an auto-approver)
+    #   * grant tailnet access to `svc:mempool` via ACL `grants`
+    #
+    # Once approved, the service is reachable at https://mempool.<tailnet>.ts.net.
+    tailscale.serve = {
+      enable = true;
+      services.mempool.endpoints."tcp:443" =
+        "http://127.0.0.1:${toString config.services.mempool.frontend.port}";
+    };
   };
 
   # Fix Lightning integration for the mempool explorer.


### PR DESCRIPTION
## What

Expose the **mempool** frontend over Tailscale using the native NixOS 26.05
[`services.tailscale.serve`](https://github.com/NixOS/nixpkgs/blob/nixos-26.05/nixos/modules/services/networking/tailscale-serve.nix)
module, so it's reachable over the tailnet without opening a port to the world.

```nix
services.tailscale.serve = {
  enable = true;
  services.mempool.endpoints."tcp:443" =
    "http://127.0.0.1:${toString config.services.mempool.frontend.port}";
};
```

## How it works

The module runs `tailscale serve set-config --all <generated.json>`. Per the
Tailscale CLI source (`cmd/tailscale/cli/serve_v2.go`, `runServeSetConfig`),
with `--all` this **both** writes the serve config **and** advertises the node
for the `svc:` services in the file — so no separate `tailscale serve advertise`
step is needed. Tailscale terminates TLS on `:443` with the tailnet cert and
reverse-proxies to the local mempool frontend.

This publishes mempool as a **Tailscale Service** (`svc:mempool`), reachable at
`https://mempool.<tailnet>.ts.net` once approved.

## Required out-of-band setup (Tailscale admin console)

This module only configures the node; the tailnet side still needs:

- [ ] Enable **MagicDNS** + **HTTPS Certificates** for the tailnet
- [ ] **Approve** the advertised `svc:mempool` service (or set an auto-approver)
- [ ] Add an ACL **`grant`** giving tailnet members access to `svc:mempool`

## Notes

- With this approach `tailscaled` reaches the backend over `127.0.0.1:60845`, so
  port `60845` no longer needs to be in `networking.firewall.allowedTCPPorts`.
  Left untouched here; can be dropped in a follow-up to make mempool tailnet-only.
- Nix eval/build validation is left to CI (no local Nix toolchain available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
