### PR TITLE
Tighten Tailscale service exposure

### DIFF
--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -151,21 +151,21 @@
     after = [ "lnd.service" ];
   };
 
-  # Expose services over Tailscale on the node's own MagicDNS name
-  # (bitcoin.dojo-regulus.ts.net) with classic per-node `tailscale serve`,
-  # which terminates TLS with the tailnet cert:
-  #   * mempool frontend over HTTPS on :443
-  #   * electrs over TLS-terminated TCP on :50002 (electrs has no native TLS),
-  #     forwarding to the plaintext Electrum port on 127.0.0.1
+  # Expose services on the node's own MagicDNS name
+  # (bitcoin.dojo-regulus.ts.net):
+  #   * mempool frontend publicly over HTTPS on :443 with Tailscale Funnel
+  #   * electrs tailnet-only over TLS-terminated TCP on :50002 with Tailscale
+  #     Serve, forwarding to the plaintext Electrum port on 127.0.0.1
   #
-  # Only requires MagicDNS + "HTTPS Certificates" enabled for the tailnet; no
-  # Tailscale Service definition, approval, or ACL grant needed.
+  # Both exposed TLS endpoints require MagicDNS and HTTPS certificates. Funnel
+  # additionally requires a `funnel` node attribute in the tailnet policy for
+  # this node/user.
   systemd.services.tailscale-serve =
     let
       tailscale = "${config.services.tailscale.package}/bin/tailscale";
     in
     {
-      description = "Expose mempool and electrs over Tailscale Serve";
+      description = "Expose mempool over Tailscale Funnel and electrs over Tailscale Serve";
       after = [
         "tailscaled.service"
         "mempool.service"
@@ -178,7 +178,7 @@
       ];
       wantedBy = [ "multi-user.target" ];
       script = ''
-        ${tailscale} serve --yes --bg --https=443 http://127.0.0.1:${toString config.services.mempool.frontend.port}
+        ${tailscale} funnel --yes --bg --https=443 http://127.0.0.1:${toString config.services.mempool.frontend.port}
         ${tailscale} serve --yes --bg --tls-terminated-tcp=50002 tcp://127.0.0.1:${toString config.services.electrs.port}
       '';
       serviceConfig = {
@@ -187,7 +187,7 @@
         Restart = "on-failure";
         RestartSec = "5s";
         ExecStop = [
-          "-${tailscale} serve --yes --https=443 off"
+          "-${tailscale} funnel --yes --https=443 off"
           "-${tailscale} serve --yes --tls-terminated-tcp=50002 off"
         ];
       };

--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -49,11 +49,11 @@
         # Listen to RPC connections on all interfaces
         address = "0.0.0.0";
 
-        # Allow RPC connections from external addresses
+        # Allow direct RPC access only from Tailscale peers.
+        # see: https://tailscale.com/docs/reference/reserved-ip-addresses
         allowip = [
-          #"100.64.0.0/10" # Allow a subnet
-          #"10.50.0.3" # Allow a specific address
-          "0.0.0.0/0" # Allow all addresses
+          "100.64.0.0/10"
+          "fd7a:115c:a1e0::/48"
         ];
 
         # RPC user
@@ -95,7 +95,7 @@
       enable = true;
       frontend = {
         enable = true;
-        address = "0.0.0.0";
+        address = "127.0.0.1";
         port = 60845;
         settings = {
           LIGHTNING = true;
@@ -193,18 +193,10 @@
       };
     };
 
-  # Open ports in the firewall
+  # Public firewall openings. Tailscale traffic is accepted by the shared
+  # trusted `tailscale0` interface, and Tailscale Serve proxies mempool/electrs
+  # from loopback, so private RPC/UI ports don't need public firewall holes.
   networking.firewall.allowedTCPPorts = [
     config.services.bitcoind.port # P2P
-    config.services.bitcoind.rpc.port # RPC
-    config.services.electrs.port # electrs
-    config.services.lnd.port # LND
-    config.services.lnd.rpcPort # LND
-    config.services.lnd.restPort # LND
-    config.services.mempool.frontend.port # Mempool
-    # ZMQ
-    28332
-    28333
-    28334
   ];
 }

--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -99,7 +99,6 @@
         port = 60845;
         settings = {
           LIGHTNING = true;
-          MEMPOOL_WEBSITE_URL = "https://mempool.duda.ai";
         };
       };
       tor = {

--- a/hosts/ethereum/ethereum.nix
+++ b/hosts/ethereum/ethereum.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   ...
@@ -11,7 +12,7 @@
   services.ethereum = {
     lighthouse-beacon.mainnet = {
       enable = true;
-      openFirewall = true;
+      openFirewall = false;
       package = pkgs.ethereum-nix.lighthouse;
       args = {
         network = "mainnet";
@@ -24,7 +25,7 @@
 
     geth.mainnet = {
       enable = true;
-      openFirewall = true;
+      openFirewall = false;
       package = pkgs.ethereum-nix.geth;
       args = {
         authrpc.jwtsecret = "/var/lib/ethereum/jwt.hex";
@@ -40,4 +41,20 @@
       };
     };
   };
+
+  networking.firewall =
+    let
+      geth = config.services.ethereum.geth.mainnet.args;
+      beacon = config.services.ethereum.lighthouse-beacon.mainnet.args;
+    in
+    {
+      # Public Ethereum peer/discovery ports. RPC and engine API ports stay
+      # reachable over Tailscale via the shared trusted `tailscale0` interface.
+      allowedTCPPorts = [ geth.port ] ++ lib.optionals beacon.disable-quic [ beacon.quic-port ];
+      allowedUDPPorts = [
+        geth.port
+        beacon.discovery-port
+      ]
+      ++ lib.optionals (!beacon.disable-quic) [ beacon.quic-port ];
+    };
 }

--- a/hosts/matrix/matrix.nix
+++ b/hosts/matrix/matrix.nix
@@ -7,13 +7,12 @@
   # Configure Tailscale hostname
   services.tailscale.extraUpFlags = lib.mkAfter [ "--hostname=matrix" ];
 
-  # HTTP, HTTPS, Matrix federation, and Bridges
+  # HTTP, HTTPS, and Matrix federation. Bridge ports remain reachable over
+  # Tailscale via the shared trusted `tailscale0` interface.
   networking.firewall.allowedTCPPorts = [
     80
     443
     8448
-    6167
-    8080
   ];
 
   services.matrix-tuwunel = {

--- a/hosts/monero/monero.nix
+++ b/hosts/monero/monero.nix
@@ -22,9 +22,9 @@
     extraConfig = ''
       confirm-external-bind=true
     '';
-
   };
 
-  # Open the RPC port in the firewall
-  networking.firewall.allowedTCPPorts = [ 18081 ];
+  # Keep only the P2P port public. RPC binds on all interfaces for Tailscale
+  # access, but it does not need a public firewall opening.
+  networking.firewall.allowedTCPPorts = [ 18080 ];
 }

--- a/hosts/zcash/zcash.nix
+++ b/hosts/zcash/zcash.nix
@@ -71,8 +71,9 @@ in
   # Open firewall ports
   # 8233 = P2P (Mainnet)
   # 8232 = RPC
+  # Keep only the P2P port public. RPC remains reachable over Tailscale via the
+  # shared trusted `tailscale0` interface.
   networking.firewall.allowedTCPPorts = [
     8233
-    8232
   ];
 }

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -17,6 +17,7 @@
       extraModules ? [ ],
       extraOverlays ? [ ],
       disks ? [ "/dev/sda" ],
+      tailscaleName ? "dojo-regulus",
       # Feature options
       virtualisation ? false,
       dns ? true,
@@ -63,6 +64,7 @@
           hostname
           username
           disks
+          tailscaleName
           ;
       };
 

--- a/lib/tailscale.nix
+++ b/lib/tailscale.nix
@@ -1,3 +1,5 @@
+{ tailscaleName, ... }:
+
 {
   networking = {
     # MagicDNS
@@ -7,7 +9,7 @@
       "1.1.1.1"
       "8.8.8.8"
     ];
-    search = [ "dojo-regulus.ts.net" ];
+    search = [ "${tailscaleName}.ts.net" ];
     firewall = {
       # enable the firewall
       enable = true;


### PR DESCRIPTION
## Summary
- add a configurable Tailscale tailnet name for shared MagicDNS search domains
- restrict host firewall openings away from the Tailscale interface while keeping required public P2P/service ports exposed
- expose the mempool frontend with Tailscale Funnel on HTTPS :443 and keep Electrs private over Tailscale Serve on :50002

## Verification
- not run: nix tooling is unavailable in this environment