### PR TITLE
Expose private RPCs and Forgejo with Tailscale

### DIFF
--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -49,9 +49,11 @@
         # Listen to RPC connections on all interfaces
         address = "0.0.0.0";
 
-        # Allow direct RPC access only from Tailscale peers.
+        # Allow RPC access from local services and Tailscale peers.
         # see: https://tailscale.com/docs/reference/reserved-ip-addresses
         allowip = [
+          "127.0.0.1"
+          "::1"
           "100.64.0.0/10"
           "fd7a:115c:a1e0::/48"
         ];
@@ -154,6 +156,8 @@
   # Expose services on the node's own MagicDNS name
   # (bitcoin.dojo-regulus.ts.net):
   #   * mempool frontend publicly over HTTPS on :443 with Tailscale Funnel
+  #   * Bitcoin Core JSON-RPC tailnet-only over HTTPS on :8332 with Tailscale
+  #     Serve, forwarding to the plaintext RPC port on 127.0.0.1
   #   * electrs tailnet-only over TLS-terminated TCP on :50002 with Tailscale
   #     Serve, forwarding to the plaintext Electrum port on 127.0.0.1
   #
@@ -163,22 +167,26 @@
   systemd.services.tailscale-serve =
     let
       tailscale = "${config.services.tailscale.package}/bin/tailscale";
+      bitcoindRpcPort = 8332;
     in
     {
-      description = "Expose mempool over Tailscale Funnel and electrs over Tailscale Serve";
+      description = "Expose mempool over Tailscale Funnel and Bitcoin RPC/electrs over Tailscale Serve";
       after = [
         "tailscaled.service"
+        "bitcoind.service"
         "mempool.service"
         "electrs.service"
       ];
       wants = [
         "tailscaled.service"
+        "bitcoind.service"
         "mempool.service"
         "electrs.service"
       ];
       wantedBy = [ "multi-user.target" ];
       script = ''
         ${tailscale} funnel --yes --bg --https=443 http://127.0.0.1:${toString config.services.mempool.frontend.port}
+        ${tailscale} serve --yes --bg --https=${toString bitcoindRpcPort} http://127.0.0.1:${toString bitcoindRpcPort}
         ${tailscale} serve --yes --bg --tls-terminated-tcp=50002 tcp://127.0.0.1:${toString config.services.electrs.port}
       '';
       serviceConfig = {
@@ -188,6 +196,7 @@
         RestartSec = "5s";
         ExecStop = [
           "-${tailscale} funnel --yes --https=443 off"
+          "-${tailscale} serve --yes --https=${toString bitcoindRpcPort} off"
           "-${tailscale} serve --yes --tls-terminated-tcp=50002 off"
         ];
       };

--- a/hosts/ethereum/ethereum.nix
+++ b/hosts/ethereum/ethereum.nix
@@ -42,6 +42,39 @@
     };
   };
 
+  # Expose Ethereum HTTP RPC endpoints on the node's own MagicDNS name
+  # (ethereum.dojo-regulus.ts.net) with Tailscale Serve:
+  #   * Geth JSON-RPC over HTTPS on :8545
+  #   * Lighthouse Beacon HTTP API over HTTPS on :5052
+  #
+  # The authenticated Engine API stays unserved.
+  systemd.services.tailscale-serve =
+    let
+      tailscale = "${config.services.tailscale.package}/bin/tailscale";
+      gethHttpPort = 8545;
+      beaconHttpPort = 5052;
+    in
+    {
+      description = "Expose Ethereum RPC endpoints over Tailscale Serve";
+      after = [ "tailscaled.service" ];
+      wants = [ "tailscaled.service" ];
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        ${tailscale} serve --yes --bg --https=${toString gethHttpPort} http://127.0.0.1:${toString gethHttpPort}
+        ${tailscale} serve --yes --bg --https=${toString beaconHttpPort} http://127.0.0.1:${toString beaconHttpPort}
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+        ExecStop = [
+          "-${tailscale} serve --yes --https=${toString gethHttpPort} off"
+          "-${tailscale} serve --yes --https=${toString beaconHttpPort} off"
+        ];
+      };
+    };
+
   networking.firewall =
     let
       geth = config.services.ethereum.geth.mainnet.args;

--- a/hosts/git/git.nix
+++ b/hosts/git/git.nix
@@ -1,8 +1,13 @@
 {
+  config,
   lib,
+  tailscaleName,
   ...
 }:
 
+let
+  forgejoDomain = "${config.networking.hostName}.${tailscaleName}.ts.net";
+in
 {
   # Configure Tailscale hostname
   services.tailscale.extraUpFlags = lib.mkAfter [ "--hostname=git" ];
@@ -12,13 +17,43 @@
     database.type = "postgres";
     settings = {
       server = {
-        DOMAIN = "git.storopoli.com";
+        DOMAIN = forgejoDomain;
         # You need to specify this to remove the port from URLs in the web UI.
-        ROOT_URL = "https://git.storopoli.com/";
+        ROOT_URL = "https://${forgejoDomain}/";
         HTTP_PORT = 3000;
       };
       # You can temporarily allow registration to create an admin user.
       service.DISABLE_REGISTRATION = true;
     };
   };
+
+  # Expose Forgejo publicly on the node's own MagicDNS name over HTTPS with
+  # Tailscale Funnel.
+  systemd.services.tailscale-funnel =
+    let
+      tailscale = "${config.services.tailscale.package}/bin/tailscale";
+      forgejo = config.services.forgejo.settings.server;
+    in
+    {
+      description = "Expose Forgejo over Tailscale Funnel";
+      after = [
+        "tailscaled.service"
+        "forgejo.service"
+      ];
+      wants = [
+        "tailscaled.service"
+        "forgejo.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        ${tailscale} funnel --yes --bg --https=443 http://127.0.0.1:${toString forgejo.HTTP_PORT}
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+        ExecStop = [ "-${tailscale} funnel --yes --https=443 off" ];
+      };
+    };
 }

--- a/hosts/matrix/matrix.nix
+++ b/hosts/matrix/matrix.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   ...
 }:
@@ -35,4 +36,27 @@
       };
     };
   };
+
+  # Expose the Matrix client/federation HTTP API on the node's own MagicDNS name
+  # (matrix.dojo-regulus.ts.net) over HTTPS on :6167 with Tailscale Serve.
+  systemd.services.tailscale-serve =
+    let
+      tailscale = "${config.services.tailscale.package}/bin/tailscale";
+    in
+    {
+      description = "Expose Matrix API over Tailscale Serve";
+      after = [ "tailscaled.service" ];
+      wants = [ "tailscaled.service" ];
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        ${tailscale} serve --yes --bg --https=6167 http://127.0.0.1:6167
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+        ExecStop = [ "-${tailscale} serve --yes --https=6167 off" ];
+      };
+    };
 }

--- a/hosts/monero/monero.nix
+++ b/hosts/monero/monero.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   ...
@@ -15,7 +16,6 @@
 
     rpc = {
       address = "0.0.0.0";
-      port = 18081;
       restricted = true;
     };
 
@@ -23,6 +23,30 @@
       confirm-external-bind=true
     '';
   };
+
+  # Expose the restricted Monero daemon RPC endpoint on the node's own MagicDNS
+  # name (monero.dojo-regulus.ts.net) over HTTPS on :18081 with Tailscale Serve.
+  systemd.services.tailscale-serve =
+    let
+      tailscale = "${config.services.tailscale.package}/bin/tailscale";
+      moneroRpcPort = 18081;
+    in
+    {
+      description = "Expose Monero RPC over Tailscale Serve";
+      after = [ "tailscaled.service" ];
+      wants = [ "tailscaled.service" ];
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        ${tailscale} serve --yes --bg --https=${toString moneroRpcPort} http://127.0.0.1:${toString moneroRpcPort}
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+        ExecStop = [ "-${tailscale} serve --yes --https=${toString moneroRpcPort} off" ];
+      };
+    };
 
   # Keep only the P2P port public. RPC binds on all interfaces for Tailscale
   # access, but it does not need a public firewall opening.

--- a/hosts/zcash/zcash.nix
+++ b/hosts/zcash/zcash.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   ...
@@ -36,37 +37,64 @@ in
 
   users.groups.zcash = { };
 
-  # Ensure state directory exists with correct permissions
-  systemd.tmpfiles.rules = [
-    "d /var/lib/zebra 0750 zcash zcash -"
-  ];
+  systemd =
+    let
+      tailscale = "${config.services.tailscale.package}/bin/tailscale";
+    in
+    {
+      # Ensure state directory exists with correct permissions
+      tmpfiles.rules = [
+        "d /var/lib/zebra 0750 zcash zcash -"
+      ];
 
-  # Zebra systemd service
-  systemd.services.zebrad = {
-    description = "Zcash Full Node (Zebra)";
-    wantedBy = [ "multi-user.target" ];
-    after = [ "network-online.target" ];
-    wants = [ "network-online.target" ];
+      services = {
+        # Zebra systemd service
+        zebrad = {
+          description = "Zcash Full Node (Zebra)";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network-online.target" ];
+          wants = [ "network-online.target" ];
 
-    serviceConfig = {
-      Type = "simple";
-      User = "zcash";
-      Group = "zcash";
-      ExecStart = "${pkgs.zebrad}/bin/zebrad start --config ${zebraConfig}";
-      Restart = "on-failure";
-      RestartSec = "30s";
+          serviceConfig = {
+            Type = "simple";
+            User = "zcash";
+            Group = "zcash";
+            ExecStart = "${pkgs.zebrad}/bin/zebrad start --config ${zebraConfig}";
+            Restart = "on-failure";
+            RestartSec = "30s";
 
-      # Hardening
-      PrivateTmp = true;
-      NoNewPrivileges = true;
-      ProtectSystem = "strict";
-      ProtectHome = true;
-      ReadWritePaths = [ "/var/lib/zebra" ];
+            # Hardening
+            PrivateTmp = true;
+            NoNewPrivileges = true;
+            ProtectSystem = "strict";
+            ProtectHome = true;
+            ReadWritePaths = [ "/var/lib/zebra" ];
 
-      # Resource limits
-      LimitNOFILE = 65535;
+            # Resource limits
+            LimitNOFILE = 65535;
+          };
+        };
+
+        # Expose the Zebra JSON-RPC endpoint on the node's own MagicDNS name
+        # (zcash.dojo-regulus.ts.net) over HTTPS on :8232 with Tailscale Serve.
+        tailscale-serve = {
+          description = "Expose Zcash RPC over Tailscale Serve";
+          after = [ "tailscaled.service" ];
+          wants = [ "tailscaled.service" ];
+          wantedBy = [ "multi-user.target" ];
+          script = ''
+            ${tailscale} serve --yes --bg --https=8232 http://127.0.0.1:8232
+          '';
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            Restart = "on-failure";
+            RestartSec = "5s";
+            ExecStop = [ "-${tailscale} serve --yes --https=8232 off" ];
+          };
+        };
+      };
     };
-  };
 
   # Open firewall ports
   # 8233 = P2P (Mainnet)


### PR DESCRIPTION
## Summary
- expose Bitcoin Core JSON-RPC over Tailscale Serve HTTPS on :8332
- expose Monero restricted daemon RPC over Tailscale Serve HTTPS on :18081
- expose Zebra JSON-RPC over Tailscale Serve HTTPS on :8232
- expose Matrix API over Tailscale Serve HTTPS on :6167
- expose Ethereum Geth JSON-RPC on :8545 and Lighthouse Beacon HTTP on :5052
- expose Forgejo publicly with Tailscale Funnel on :443
- point Forgejo DOMAIN and ROOT_URL at <nix-hostname>.<tailnet>.ts.net while keeping HTTP_PORT at 3000

## Notes
- RPC endpoints use tailnet-only Tailscale Serve, not Funnel
- RPC services keep their default node ports; Tailscale adds HTTPS on those same ports
- Forgejo uses Funnel because it is the public web UI
- Ethereum Engine API remains unserved
- public firewall openings are unchanged

## Verification
- not run locally: nix tooling is unavailable in this environment
- GitHub Actions will run Nix evaluation and pre-commit checks