### PR TITLE
Route served RPC backends through Tailscale Serve

### DIFF
--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -46,16 +46,14 @@
       address = "0.0.0.0";
 
       rpc = {
-        # Listen to RPC connections on all interfaces
-        address = "0.0.0.0";
+        # Listen to local RPC connections only; Tailscale Serve exposes this
+        # over HTTPS on the node's MagicDNS name.
+        address = "127.0.0.1";
 
-        # Allow RPC access from local services and Tailscale peers.
-        # see: https://tailscale.com/docs/reference/reserved-ip-addresses
+        # Allow RPC access from local services and the Tailscale Serve proxy.
         allowip = [
           "127.0.0.1"
           "::1"
-          "100.64.0.0/10"
-          "fd7a:115c:a1e0::/48"
         ];
 
         # RPC user

--- a/hosts/ethereum/ethereum.nix
+++ b/hosts/ethereum/ethereum.nix
@@ -16,7 +16,7 @@
       package = pkgs.ethereum-nix.lighthouse;
       args = {
         network = "mainnet";
-        http.address = "0.0.0.0";
+        http.address = "127.0.0.1";
         execution-jwt = "/var/lib/ethereum/jwt.hex";
         execution-endpoint = "http://127.0.0.1:8551";
         checkpoint-sync-url = "https://beaconstate.ethstaker.cc";
@@ -31,7 +31,7 @@
         authrpc.jwtsecret = "/var/lib/ethereum/jwt.hex";
         http = {
           enable = true;
-          addr = "0.0.0.0";
+          addr = "127.0.0.1";
           api = [
             "net"
             "web3"
@@ -82,7 +82,8 @@
     in
     {
       # Public Ethereum peer/discovery ports. RPC and engine API ports stay
-      # reachable over Tailscale via the shared trusted `tailscale0` interface.
+      # reachable over HTTPS via Tailscale Serve instead of tailnet-facing
+      # plaintext listeners.
       allowedTCPPorts = [ geth.port ] ++ lib.optionals beacon.disable-quic [ beacon.quic-port ];
       allowedUDPPorts = [
         geth.port

--- a/hosts/matrix/matrix.nix
+++ b/hosts/matrix/matrix.nix
@@ -21,7 +21,7 @@
     settings = {
       global = {
         server_name = "storopoli.com";
-        address = [ "0.0.0.0" ];
+        address = [ "127.0.0.1" ];
         allow_registration = false;
         allow_encryption = true;
         allow_federation = true;

--- a/hosts/monero/monero.nix
+++ b/hosts/monero/monero.nix
@@ -15,13 +15,9 @@
     enable = true;
 
     rpc = {
-      address = "0.0.0.0";
+      address = "127.0.0.1";
       restricted = true;
     };
-
-    extraConfig = ''
-      confirm-external-bind=true
-    '';
   };
 
   # Expose the restricted Monero daemon RPC endpoint on the node's own MagicDNS
@@ -48,7 +44,8 @@
       };
     };
 
-  # Keep only the P2P port public. RPC binds on all interfaces for Tailscale
-  # access, but it does not need a public firewall opening.
+  # Keep only the P2P port public. Tailscale Serve proxies RPC from loopback,
+  # so it does not need a public firewall opening or a tailnet-facing plaintext
+  # listener.
   networking.firewall.allowedTCPPorts = [ 18080 ];
 }

--- a/hosts/zcash/zcash.nix
+++ b/hosts/zcash/zcash.nix
@@ -16,7 +16,7 @@ let
     cache_dir = "/var/lib/zebra"
 
     [rpc]
-    listen_addr = "0.0.0.0:8232"
+    listen_addr = "127.0.0.1:8232"
     enable_cookie_auth = false
 
     [tracing]
@@ -99,8 +99,9 @@ in
   # Open firewall ports
   # 8233 = P2P (Mainnet)
   # 8232 = RPC
-  # Keep only the P2P port public. RPC remains reachable over Tailscale via the
-  # shared trusted `tailscale0` interface.
+  # Keep only the P2P port public. Tailscale Serve proxies RPC from loopback,
+  # so it does not need a public firewall opening or a tailnet-facing plaintext
+  # listener.
   networking.firewall.allowedTCPPorts = [
     8233
   ];


### PR DESCRIPTION
## Summary
- bind Bitcoin Core RPC to localhost while preserving the Tailscale Serve HTTPS endpoint on :8332
- bind Electrs to localhost while preserving the Tailscale Serve TLS endpoint on :50002
- bind Monero restricted RPC, Zebra RPC, Ethereum HTTP RPCs, and Matrix API to localhost
- remove Monero external-bind confirmation because its RPC listener no longer binds externally

## Why
When a backend RPC service binds directly on the Tailscale interface on the same port Tailscale Serve is meant to expose, clients can hit the plaintext HTTP listener instead of the Tailscale TLS listener. That produces curl TLS failures such as `wrong version number`.

Electrs used a different public Serve port, but binding it to localhost prevents direct plaintext access on its backend port.

## Verification
- not run locally: nix tooling is unavailable in this environment
- GitHub Actions will run Nix evaluation and pre-commit checks