### PR TITLE
Use TLS-terminated Tailscale Serve for RPC ports

### DIFF
--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -83,8 +83,9 @@
     electrs = {
       enable = true;
 
-      # Listen to connections on all interfaces
-      address = "0.0.0.0";
+      # Listen to local connections only; Tailscale Serve exposes Electrs over
+      # TLS on the node's MagicDNS name.
+      address = "127.0.0.1";
 
       # Set this if you're using the `secure-node.nix` template
       tor.enforce = false;

--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -147,85 +147,87 @@
   # Ordering the backend after `lnd.service` (which only becomes active once
   # its ExecStartPost macaroon creation has completed) makes the macaroon
   # guaranteed to exist before mempool reads it.
-  systemd.services.mempool = {
-    wants = [ "lnd.service" ];
-    after = [ "lnd.service" ];
-  };
-
-  # Expose services on the node's own MagicDNS name
-  # (bitcoin.dojo-regulus.ts.net):
-  #   * mempool frontend publicly over HTTPS on :443 with Tailscale Funnel
-  #
-  # Funnel requires a `funnel` node attribute in the tailnet policy for this
-  # node/user.
-  systemd.services.tailscale-funnel =
-    let
-      tailscale = "${config.services.tailscale.package}/bin/tailscale";
-    in
-    {
-      description = "Expose mempool over Tailscale Funnel";
-      after = [
-        "tailscaled.service"
-        "mempool.service"
-      ];
-      wants = [
-        "tailscaled.service"
-        "mempool.service"
-      ];
-      wantedBy = [ "multi-user.target" ];
-      script = ''
-        ${tailscale} funnel --yes --bg --https=443 http://127.0.0.1:${toString config.services.mempool.frontend.port}
-      '';
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-        Restart = "on-failure";
-        RestartSec = "5s";
-        ExecStop = [ "-${tailscale} funnel --yes --https=443 off" ];
-      };
+  systemd.services = {
+    mempool = {
+      wants = [ "lnd.service" ];
+      after = [ "lnd.service" ];
     };
 
-  # Expose private services on the node's own MagicDNS name
-  # (bitcoin.dojo-regulus.ts.net):
-  #   * Bitcoin Core JSON-RPC tailnet-only over TLS-terminated TCP on :8332 with
-  #     Tailscale Serve, forwarding to the plaintext RPC port on 127.0.0.1
-  #   * electrs tailnet-only over TLS-terminated TCP on :50002 with Tailscale
-  #     Serve, forwarding to the plaintext Electrum port on 127.0.0.1
-  #
-  # These exposed TLS endpoints require MagicDNS and HTTPS certificates.
-  systemd.services.tailscale-serve =
-    let
-      tailscale = "${config.services.tailscale.package}/bin/tailscale";
-      bitcoindRpcPort = 8332;
-    in
-    {
-      description = "Expose Bitcoin RPC and electrs over Tailscale Serve";
-      after = [
-        "tailscaled.service"
-        "bitcoind.service"
-        "electrs.service"
-      ];
-      wants = [
-        "tailscaled.service"
-        "bitcoind.service"
-        "electrs.service"
-      ];
-      wantedBy = [ "multi-user.target" ];
-      script = ''
-        ${tailscale} serve --yes --bg --tls-terminated-tcp=${toString bitcoindRpcPort} tcp://127.0.0.1:${toString bitcoindRpcPort}
-        ${tailscale} serve --yes --bg --tls-terminated-tcp=50002 tcp://127.0.0.1:${toString config.services.electrs.port}
-      '';
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-        Restart = "on-failure";
-        RestartSec = "5s";
-        ExecStop = [
-          "-${tailscale} serve --yes --tls-terminated-tcp=${toString bitcoindRpcPort} off"
-          "-${tailscale} serve --yes --tls-terminated-tcp=50002 off"
+    # Expose services on the node's own MagicDNS name
+    # (bitcoin.dojo-regulus.ts.net):
+    #   * mempool frontend publicly over HTTPS on :443 with Tailscale Funnel
+    #
+    # Funnel requires a `funnel` node attribute in the tailnet policy for this
+    # node/user.
+    tailscale-funnel =
+      let
+        tailscale = "${config.services.tailscale.package}/bin/tailscale";
+      in
+      {
+        description = "Expose mempool over Tailscale Funnel";
+        after = [
+          "tailscaled.service"
+          "mempool.service"
         ];
+        wants = [
+          "tailscaled.service"
+          "mempool.service"
+        ];
+        wantedBy = [ "multi-user.target" ];
+        script = ''
+          ${tailscale} funnel --yes --bg --https=443 http://127.0.0.1:${toString config.services.mempool.frontend.port}
+        '';
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          Restart = "on-failure";
+          RestartSec = "5s";
+          ExecStop = [ "-${tailscale} funnel --yes --https=443 off" ];
+        };
       };
-    };
+
+    # Expose private services on the node's own MagicDNS name
+    # (bitcoin.dojo-regulus.ts.net):
+    #   * Bitcoin Core JSON-RPC tailnet-only over TLS-terminated TCP on :8332 with
+    #     Tailscale Serve, forwarding to the plaintext RPC port on 127.0.0.1
+    #   * electrs tailnet-only over TLS-terminated TCP on :50002 with Tailscale
+    #     Serve, forwarding to the plaintext Electrum port on 127.0.0.1
+    #
+    # These exposed TLS endpoints require MagicDNS and HTTPS certificates.
+    tailscale-serve =
+      let
+        tailscale = "${config.services.tailscale.package}/bin/tailscale";
+        bitcoindRpcPort = 8332;
+      in
+      {
+        description = "Expose Bitcoin RPC and electrs over Tailscale Serve";
+        after = [
+          "tailscaled.service"
+          "bitcoind.service"
+          "electrs.service"
+        ];
+        wants = [
+          "tailscaled.service"
+          "bitcoind.service"
+          "electrs.service"
+        ];
+        wantedBy = [ "multi-user.target" ];
+        script = ''
+          ${tailscale} serve --yes --bg --tls-terminated-tcp=${toString bitcoindRpcPort} tcp://127.0.0.1:${toString bitcoindRpcPort}
+          ${tailscale} serve --yes --bg --tls-terminated-tcp=50002 tcp://127.0.0.1:${toString config.services.electrs.port}
+        '';
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          Restart = "on-failure";
+          RestartSec = "5s";
+          ExecStop = [
+            "-${tailscale} serve --yes --tls-terminated-tcp=${toString bitcoindRpcPort} off"
+            "-${tailscale} serve --yes --tls-terminated-tcp=50002 off"
+          ];
+        };
+      };
+  };
 
   # Public firewall openings. Tailscale traffic is accepted by the shared
   # trusted `tailscale0` interface, and Tailscale Serve proxies mempool/electrs

--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -155,37 +155,64 @@
   # Expose services on the node's own MagicDNS name
   # (bitcoin.dojo-regulus.ts.net):
   #   * mempool frontend publicly over HTTPS on :443 with Tailscale Funnel
-  #   * Bitcoin Core JSON-RPC tailnet-only over HTTPS on :8332 with Tailscale
-  #     Serve, forwarding to the plaintext RPC port on 127.0.0.1
+  #
+  # Funnel requires a `funnel` node attribute in the tailnet policy for this
+  # node/user.
+  systemd.services.tailscale-funnel =
+    let
+      tailscale = "${config.services.tailscale.package}/bin/tailscale";
+    in
+    {
+      description = "Expose mempool over Tailscale Funnel";
+      after = [
+        "tailscaled.service"
+        "mempool.service"
+      ];
+      wants = [
+        "tailscaled.service"
+        "mempool.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        ${tailscale} funnel --yes --bg --https=443 http://127.0.0.1:${toString config.services.mempool.frontend.port}
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+        ExecStop = [ "-${tailscale} funnel --yes --https=443 off" ];
+      };
+    };
+
+  # Expose private services on the node's own MagicDNS name
+  # (bitcoin.dojo-regulus.ts.net):
+  #   * Bitcoin Core JSON-RPC tailnet-only over TLS-terminated TCP on :8332 with
+  #     Tailscale Serve, forwarding to the plaintext RPC port on 127.0.0.1
   #   * electrs tailnet-only over TLS-terminated TCP on :50002 with Tailscale
   #     Serve, forwarding to the plaintext Electrum port on 127.0.0.1
   #
-  # Both exposed TLS endpoints require MagicDNS and HTTPS certificates. Funnel
-  # additionally requires a `funnel` node attribute in the tailnet policy for
-  # this node/user.
+  # These exposed TLS endpoints require MagicDNS and HTTPS certificates.
   systemd.services.tailscale-serve =
     let
       tailscale = "${config.services.tailscale.package}/bin/tailscale";
       bitcoindRpcPort = 8332;
     in
     {
-      description = "Expose mempool over Tailscale Funnel and Bitcoin RPC/electrs over Tailscale Serve";
+      description = "Expose Bitcoin RPC and electrs over Tailscale Serve";
       after = [
         "tailscaled.service"
         "bitcoind.service"
-        "mempool.service"
         "electrs.service"
       ];
       wants = [
         "tailscaled.service"
         "bitcoind.service"
-        "mempool.service"
         "electrs.service"
       ];
       wantedBy = [ "multi-user.target" ];
       script = ''
-        ${tailscale} funnel --yes --bg --https=443 http://127.0.0.1:${toString config.services.mempool.frontend.port}
-        ${tailscale} serve --yes --bg --https=${toString bitcoindRpcPort} http://127.0.0.1:${toString bitcoindRpcPort}
+        ${tailscale} serve --yes --bg --tls-terminated-tcp=${toString bitcoindRpcPort} tcp://127.0.0.1:${toString bitcoindRpcPort}
         ${tailscale} serve --yes --bg --tls-terminated-tcp=50002 tcp://127.0.0.1:${toString config.services.electrs.port}
       '';
       serviceConfig = {
@@ -194,8 +221,7 @@
         Restart = "on-failure";
         RestartSec = "5s";
         ExecStop = [
-          "-${tailscale} funnel --yes --https=443 off"
-          "-${tailscale} serve --yes --https=${toString bitcoindRpcPort} off"
+          "-${tailscale} serve --yes --tls-terminated-tcp=${toString bitcoindRpcPort} off"
           "-${tailscale} serve --yes --tls-terminated-tcp=50002 off"
         ];
       };

--- a/hosts/ethereum/ethereum.nix
+++ b/hosts/ethereum/ethereum.nix
@@ -44,8 +44,8 @@
 
   # Expose Ethereum HTTP RPC endpoints on the node's own MagicDNS name
   # (ethereum.dojo-regulus.ts.net) with Tailscale Serve:
-  #   * Geth JSON-RPC over HTTPS on :8545
-  #   * Lighthouse Beacon HTTP API over HTTPS on :5052
+  #   * Geth JSON-RPC over TLS-terminated TCP on :8545
+  #   * Lighthouse Beacon HTTP API over TLS-terminated TCP on :5052
   #
   # The authenticated Engine API stays unserved.
   systemd.services.tailscale-serve =
@@ -60,8 +60,8 @@
       wants = [ "tailscaled.service" ];
       wantedBy = [ "multi-user.target" ];
       script = ''
-        ${tailscale} serve --yes --bg --https=${toString gethHttpPort} http://127.0.0.1:${toString gethHttpPort}
-        ${tailscale} serve --yes --bg --https=${toString beaconHttpPort} http://127.0.0.1:${toString beaconHttpPort}
+        ${tailscale} serve --yes --bg --tls-terminated-tcp=${toString gethHttpPort} tcp://127.0.0.1:${toString gethHttpPort}
+        ${tailscale} serve --yes --bg --tls-terminated-tcp=${toString beaconHttpPort} tcp://127.0.0.1:${toString beaconHttpPort}
       '';
       serviceConfig = {
         Type = "oneshot";
@@ -69,8 +69,8 @@
         Restart = "on-failure";
         RestartSec = "5s";
         ExecStop = [
-          "-${tailscale} serve --yes --https=${toString gethHttpPort} off"
-          "-${tailscale} serve --yes --https=${toString beaconHttpPort} off"
+          "-${tailscale} serve --yes --tls-terminated-tcp=${toString gethHttpPort} off"
+          "-${tailscale} serve --yes --tls-terminated-tcp=${toString beaconHttpPort} off"
         ];
       };
     };

--- a/hosts/matrix/matrix.nix
+++ b/hosts/matrix/matrix.nix
@@ -38,7 +38,8 @@
   };
 
   # Expose the Matrix client/federation HTTP API on the node's own MagicDNS name
-  # (matrix.dojo-regulus.ts.net) over HTTPS on :6167 with Tailscale Serve.
+  # (matrix.dojo-regulus.ts.net) over TLS-terminated TCP on :6167 with
+  # Tailscale Serve.
   systemd.services.tailscale-serve =
     let
       tailscale = "${config.services.tailscale.package}/bin/tailscale";
@@ -49,14 +50,14 @@
       wants = [ "tailscaled.service" ];
       wantedBy = [ "multi-user.target" ];
       script = ''
-        ${tailscale} serve --yes --bg --https=6167 http://127.0.0.1:6167
+        ${tailscale} serve --yes --bg --tls-terminated-tcp=6167 tcp://127.0.0.1:6167
       '';
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
         Restart = "on-failure";
         RestartSec = "5s";
-        ExecStop = [ "-${tailscale} serve --yes --https=6167 off" ];
+        ExecStop = [ "-${tailscale} serve --yes --tls-terminated-tcp=6167 off" ];
       };
     };
 }

--- a/hosts/monero/monero.nix
+++ b/hosts/monero/monero.nix
@@ -21,7 +21,8 @@
   };
 
   # Expose the restricted Monero daemon RPC endpoint on the node's own MagicDNS
-  # name (monero.dojo-regulus.ts.net) over HTTPS on :18081 with Tailscale Serve.
+  # name (monero.dojo-regulus.ts.net) over TLS-terminated TCP on :18081 with
+  # Tailscale Serve.
   systemd.services.tailscale-serve =
     let
       tailscale = "${config.services.tailscale.package}/bin/tailscale";
@@ -33,14 +34,14 @@
       wants = [ "tailscaled.service" ];
       wantedBy = [ "multi-user.target" ];
       script = ''
-        ${tailscale} serve --yes --bg --https=${toString moneroRpcPort} http://127.0.0.1:${toString moneroRpcPort}
+        ${tailscale} serve --yes --bg --tls-terminated-tcp=${toString moneroRpcPort} tcp://127.0.0.1:${toString moneroRpcPort}
       '';
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
         Restart = "on-failure";
         RestartSec = "5s";
-        ExecStop = [ "-${tailscale} serve --yes --https=${toString moneroRpcPort} off" ];
+        ExecStop = [ "-${tailscale} serve --yes --tls-terminated-tcp=${toString moneroRpcPort} off" ];
       };
     };
 

--- a/hosts/zcash/zcash.nix
+++ b/hosts/zcash/zcash.nix
@@ -76,21 +76,22 @@ in
         };
 
         # Expose the Zebra JSON-RPC endpoint on the node's own MagicDNS name
-        # (zcash.dojo-regulus.ts.net) over HTTPS on :8232 with Tailscale Serve.
+        # (zcash.dojo-regulus.ts.net) over TLS-terminated TCP on :8232 with
+        # Tailscale Serve.
         tailscale-serve = {
           description = "Expose Zcash RPC over Tailscale Serve";
           after = [ "tailscaled.service" ];
           wants = [ "tailscaled.service" ];
           wantedBy = [ "multi-user.target" ];
           script = ''
-            ${tailscale} serve --yes --bg --https=8232 http://127.0.0.1:8232
+            ${tailscale} serve --yes --bg --tls-terminated-tcp=8232 tcp://127.0.0.1:8232
           '';
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = true;
             Restart = "on-failure";
             RestartSec = "5s";
-            ExecStop = [ "-${tailscale} serve --yes --https=8232 off" ];
+            ExecStop = [ "-${tailscale} serve --yes --tls-terminated-tcp=8232 off" ];
           };
         };
       };


### PR DESCRIPTION
## Summary
- bind the electrs backend to loopback before serving it through Tailscale
- switch Bitcoin, Monero, Zcash, Matrix, and Ethereum RPC/API Serve endpoints from `--https` reverse proxy mode to `--tls-terminated-tcp` on their native ports
- split Bitcoin mempool Funnel from tailnet-only Bitcoin RPC/electrs Serve so Funnel setup cannot prevent private RPC listeners from being configured

## Verification
- `nix fmt` could not run locally: `nix` is not installed in this environment
- GitHub Actions will run the host Nix tests on the pushed branch

## Notes
This keeps Forgejo and mempool on Funnel/`:443`, while private RPC/API ports use the same TLS-terminated TCP mode that works for electrs on `:50002`.
