### PR TITLE
fix(security): harden shared baseline and bitcoin host

### DIFF
--- a/hosts/bitcoin/bitcoin.nix
+++ b/hosts/bitcoin/bitcoin.nix
@@ -102,10 +102,6 @@ in
         users.public.name = "bitcoin";
       };
 
-      # ZMQ
-      zmqpubrawblock = "tcp://0.0.0.0:28332";
-      zmqpubrawtx = "tcp://0.0.0.0:28333";
-
       extraConfig = ''
         mempoolfullrbf=1
         blockfilterindex=1 # BIP158 compact block filters (needed by Wasabi RPC)
@@ -165,14 +161,22 @@ in
     lnd = {
       enable = true;
       address = "0.0.0.0";
-      rpcAddress = "0.0.0.0";
-      restAddress = "0.0.0.0";
-      certificate.extraIPs = [ "0.0.0.0" ];
+
+      # Listen to local connections only; remote access goes through the
+      # lnd-rpc/lnd-rest onion services, which target these addresses.
+      rpcAddress = "127.0.0.1";
+      restAddress = "127.0.0.1";
       macaroons.mempool = {
         inherit (config.services.mempool) user;
         permissions = ''{"entity":"info","action":"read"},{"entity":"onchain","action":"read"},{"entity":"offchain","action":"read"},{"entity":"address","action":"read"},{"entity":"message","action":"read"},{"entity":"peers","action":"read"},{"entity":"signer","action":"read"},{"entity":"invoices","action":"read"},{"entity":"macaroon","action":"read"}'';
       };
     };
+
+    # Keep longer logs than the shared 36h baseline: this host runs
+    # financial infrastructure and needs history for incident response.
+    journald.extraConfig = lib.mkForce ''
+      MaxRetentionSec=3month
+    '';
   };
 
   # Fix Lightning integration for the mempool explorer.

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -42,15 +42,11 @@
     p7zip
   ];
 
-  # root password
-  users.users.root.hashedPassword = "$y$j9T$bQQD1tHdgxA4qTFI1s4ih/$zOgREkZW2woes8c741V4mPpY0EP.7LlUu3MVVFGTnJ.";
-
   # Userland
   users.users.${username} = {
     isNormalUser = true;
     description = "user";
     extraGroups = [ "wheel" ];
-    hashedPassword = "$y$j9T$cQZQPmIVl64rervwIFIAT1$ZVLx2KkTMnWpCGKnxqHv.ptnz7pGl2WzBxkUyeQsXFB";
     packages = with pkgs; [
       hello
     ];
@@ -77,10 +73,6 @@
         "flakes"
       ];
       warn-dirty = false;
-      trusted-users = [
-        "@wheel"
-        "${username}"
-      ];
       # 500mb buffer
       download-buffer-size = 500000000;
       auto-optimise-store = true;
@@ -106,12 +98,4 @@
   # System localization
   time.timeZone = "UTC";
   i18n.defaultLocale = "en_US.UTF-8";
-
-  # Hardware configuration
-  hardware = {
-    graphics = {
-      enable = true;
-      enable32Bit = true;
-    };
-  };
 }

--- a/lib/doas.nix
+++ b/lib/doas.nix
@@ -13,7 +13,6 @@
         users = [ "${username}" ];
         # Keys-only access model: no local password prompts.
         noPass = true;
-        keepEnv = true;
         persist = false;
       }
     ];


### PR DESCRIPTION
- hosts/default.nix: drop committed password hashes (dead config —
  security-baseline already locks both passwords), remove nix
  trusted-users (root-equivalent via substituter/build-hook tricks),
  drop unused graphics stack on headless servers
- lib/doas.nix: remove keepEnv from the passwordless doas rule
- bitcoin: bind LND RPC/REST to loopback (remote access stays via the
  lnd-rpc/lnd-rest onion services), drop the ZMQ 0.0.0.0 overrides so
  nix-bitcoin's loopback default applies, keep 3 months of journald
  logs for incident response